### PR TITLE
新增进度条、TMDB缓存及一些自用小修改

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 * [刮削攻略](刮削攻略.md)
 
 ## 2 Last Update
+* 2025.12.24 TMDB查询缓存：自动缓存TMDB查询结果到 `~/.torcp/tmdb_cache.json`，30天过期。使用 `--no-tmdb-cache` 禁用，`--clear-tmdb-cache` 清除缓存
 * 2025.12.24 `--progress` 显示进度条，处理大量文件时可显示处理进度
 * 2025.7.27 支持strm；更新 tmdbv3api
 * 2024.11.21 查 IMDb 由 episode 获取 series 的 IMDb，再查 TMDb
@@ -85,7 +86,7 @@ usage: tp.py [-h] -d HD_PATH [-e KEEP_EXT] [-l LANG] [--genre GENRE] [--other-di
              [--tv-folder-name TV_FOLDER_NAME] [--movie-folder-name MOVIE_FOLDER_NAME] [--tv] [--movie] [--dryrun] [--single] [--extract-bdmv] [--full-bdmv] [--origin-name] [--tmdb-origin-name]
              [--sleep SLEEP] [--move-run] [--make-log] [--symbolink] [--cache] [--emby-bracket] [--plex-bracket] [--make-plex-match] [--make-nfo] [--after-copy-script AFTER_COPY_SCRIPT]
              [--imdbid IMDBID] [--tmdbid TMDBID] [--extitle EXTITLE] [--site-str SITE_STR] [--add-year-dir] [--genre-with-area GENRE_WITH_AREA]
-             [--progress]
+             [--progress] [--no-tmdb-cache] [--clear-tmdb-cache]
              MEDIA_DIR
 
 torcp: a script hardlink media files and directories in Emby-happy naming and structs.
@@ -141,6 +142,8 @@ options:
   --genre-with-area GENRE_WITH_AREA
                         specify genres with area subdir, seperated with comma
   --progress            enable progress bar display
+  --no-tmdb-cache       disable TMDB query cache
+  --clear-tmdb-cache    clear TMDB cache before running
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 * [刮削攻略](刮削攻略.md)
 
 ## 2 Last Update
+* 2025.12.24 处理报告：运行结束后显示处理统计，包括跳过和失败的项目。使用 `--save-skipped` 和 `--save-failed` 保存到文件
 * 2025.12.24 TMDB查询缓存：自动缓存TMDB查询结果到 `~/.torcp/tmdb_cache.json`，30天过期。使用 `--no-tmdb-cache` 禁用，`--clear-tmdb-cache` 清除缓存
 * 2025.12.24 `--progress` 显示进度条，处理大量文件时可显示处理进度
 * 2025.7.27 支持strm；更新 tmdbv3api
@@ -144,6 +145,8 @@ options:
   --progress            enable progress bar display
   --no-tmdb-cache       disable TMDB query cache
   --clear-tmdb-cache    clear TMDB cache before running
+  --save-skipped FILE   save skipped items list to specified file
+  --save-failed FILE    save failed items list to specified file
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 * [刮削攻略](刮削攻略.md)
 
 ## 2 Last Update
+* 2025.12.24 `--progress` 显示进度条，处理大量文件时可显示处理进度
 * 2025.7.27 支持strm；更新 tmdbv3api
 * 2024.11.21 查 IMDb 由 episode 获取 series 的 IMDb，再查 TMDb
 * 2024.10.23 `--add-year-dir` 在媒体名称目录之上，加一层年份目录
@@ -84,6 +85,7 @@ usage: tp.py [-h] -d HD_PATH [-e KEEP_EXT] [-l LANG] [--genre GENRE] [--other-di
              [--tv-folder-name TV_FOLDER_NAME] [--movie-folder-name MOVIE_FOLDER_NAME] [--tv] [--movie] [--dryrun] [--single] [--extract-bdmv] [--full-bdmv] [--origin-name] [--tmdb-origin-name]
              [--sleep SLEEP] [--move-run] [--make-log] [--symbolink] [--cache] [--emby-bracket] [--plex-bracket] [--make-plex-match] [--make-nfo] [--after-copy-script AFTER_COPY_SCRIPT]
              [--imdbid IMDBID] [--tmdbid TMDBID] [--extitle EXTITLE] [--site-str SITE_STR] [--add-year-dir] [--genre-with-area GENRE_WITH_AREA]
+             [--progress]
              MEDIA_DIR
 
 torcp: a script hardlink media files and directories in Emby-happy naming and structs.
@@ -137,7 +139,8 @@ options:
   --site-str SITE_STR   site-id(ex. hds-12345) folder name, set site strs like ('chd,hds,ade,ttg').
   --add-year-dir        Add a year dir above the media folder
   --genre-with-area GENRE_WITH_AREA
-                        specify genres with area subdir, seperated with comma  
+                        specify genres with area subdir, seperated with comma
+  --progress            enable progress bar display
 ```
 
 

--- a/README_en.md
+++ b/README_en.md
@@ -8,6 +8,7 @@ A script to organize media files in Emby-happy way, create hardlink in a seperat
 
 ## Last update:
 * ...refer to [chinese version](README.md).....
+* 2025.12.24: Unified folder handling: `--unified-folders` to merge BDMV/ISO into Movie/TV folders based on content category. HDTV is now always treated as TV. `--tmdb-not-found-folder` to customize the folder name for TMDb lookup failures. Fixes bug where HDTV items that fail TMDb lookup went to HDTV folder instead of TMDbNotFound
 * 2025.12.24: Processing report: shows summary at end with skipped/failed items. Use `--save-skipped` and `--save-failed` to save to files
 * 2025.12.24: TMDB query cache: auto-caches TMDB queries to `~/.torcp/tmdb_cache.json` with 30-day expiry. Use `--no-tmdb-cache` to disable, `--clear-tmdb-cache` to clear cache
 * 2025.12.24: `--progress` enable progress bar display when processing files
@@ -93,6 +94,9 @@ options:
   --clear-tmdb-cache    clear TMDB cache before running
   --save-skipped FILE   save skipped items list to specified file
   --save-failed FILE    save failed items list to specified file
+  --unified-folders     merge BDMV/ISO into Movie/TV folders based on content category
+  --tmdb-not-found-folder FOLDER
+                        folder name for items that fail TMDb lookup (default: TMDbNotFound)
 ```
 
 ### Alternatively, call with `python tp.py`

--- a/README_en.md
+++ b/README_en.md
@@ -8,6 +8,7 @@ A script to organize media files in Emby-happy way, create hardlink in a seperat
 
 ## Last update:
 * ...refer to [chinese version](README.md).....
+* 2025.12.24: `--progress` enable progress bar display when processing files
 * 2022.4.3: `--make-log` create a log file to trace the origin file location and folder name
 * 2022.3.23: `--symbolink` support symbol link
 * 2022.3.13: `--lang` dispatch to different folders base on TMDb language

--- a/README_en.md
+++ b/README_en.md
@@ -8,6 +8,7 @@ A script to organize media files in Emby-happy way, create hardlink in a seperat
 
 ## Last update:
 * ...refer to [chinese version](README.md).....
+* 2025.12.24: Processing report: shows summary at end with skipped/failed items. Use `--save-skipped` and `--save-failed` to save to files
 * 2025.12.24: TMDB query cache: auto-caches TMDB queries to `~/.torcp/tmdb_cache.json` with 30-day expiry. Use `--no-tmdb-cache` to disable, `--clear-tmdb-cache` to clear cache
 * 2025.12.24: `--progress` enable progress bar display when processing files
 * 2022.4.3: `--make-log` create a log file to trace the origin file location and folder name
@@ -90,6 +91,8 @@ options:
   --progress            enable progress bar display
   --no-tmdb-cache       disable TMDB query cache
   --clear-tmdb-cache    clear TMDB cache before running
+  --save-skipped FILE   save skipped items list to specified file
+  --save-failed FILE    save failed items list to specified file
 ```
 
 ### Alternatively, call with `python tp.py`

--- a/README_en.md
+++ b/README_en.md
@@ -8,6 +8,7 @@ A script to organize media files in Emby-happy way, create hardlink in a seperat
 
 ## Last update:
 * ...refer to [chinese version](README.md).....
+* 2025.12.24: TMDB query cache: auto-caches TMDB queries to `~/.torcp/tmdb_cache.json` with 30-day expiry. Use `--no-tmdb-cache` to disable, `--clear-tmdb-cache` to clear cache
 * 2025.12.24: `--progress` enable progress bar display when processing files
 * 2022.4.3: `--make-log` create a log file to trace the origin file location and folder name
 * 2022.3.23: `--symbolink` support symbol link
@@ -31,6 +32,7 @@ usage: tp.py [-h] -d HD_PATH [-e KEEP_EXT] [-l LANG] [--genre GENRE] [--other-di
              [--tv-folder-name TV_FOLDER_NAME] [--movie-folder-name MOVIE_FOLDER_NAME] [--tv] [--movie] [--dryrun] [--single] [--extract-bdmv] [--full-bdmv] [--origin-name] [--tmdb-origin-name]
              [--sleep SLEEP] [--move-run] [--make-log] [--symbolink] [--cache] [--emby-bracket] [--plex-bracket] [--make-plex-match] [--make-nfo] [--after-copy-script AFTER_COPY_SCRIPT]
              [--imdbid IMDBID] [--tmdbid TMDBID] [--extitle EXTITLE] [--site-str SITE_STR] [--add-year-dir] [--genre-with-area GENRE_WITH_AREA]
+             [--progress] [--no-tmdb-cache] [--clear-tmdb-cache]
              MEDIA_DIR
 
 torcp: a script hardlink media files and directories in Emby-happy naming and structs.
@@ -84,7 +86,10 @@ options:
   --site-str SITE_STR   site-id(ex. hds-12345) folder name, set site strs like ('chd,hds,ade,ttg').
   --add-year-dir        Add a year dir above the media folder
   --genre-with-area GENRE_WITH_AREA
-                        specify genres with area subdir, seperated with comma  
+                        specify genres with area subdir, seperated with comma
+  --progress            enable progress bar display
+  --no-tmdb-cache       disable TMDB query cache
+  --clear-tmdb-cache    clear TMDB cache before running
 ```
 
 ### Alternatively, call with `python tp.py`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 tmdbv3api==1.7.7
 cinemagoer
+rich>=13.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ platforms = any
 include_package_data = True
 install_requires =
     tmdbv3api
+    cinemagoer
+    rich>=13.0.0
 python_requires = >=3.6
 setup_requires =
     setuptools_scm

--- a/torcp/progress.py
+++ b/torcp/progress.py
@@ -48,7 +48,7 @@ class TorcpProgress:
             console=self.progress.console,
             show_time=True,
             show_path=False,
-            markup=True,
+            markup=False,
             rich_tracebacks=True
         )
         rich_handler.setFormatter(logging.Formatter("%(message)s"))

--- a/torcp/progress.py
+++ b/torcp/progress.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+"""
+Progress bar utilities for torcp operations.
+"""
+
+import logging
+from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn, TimeRemainingColumn
+from rich.console import Console
+from rich.logging import RichHandler
+
+
+class TorcpProgress:
+    """Progress manager for torcp operations with multi-level progress tracking."""
+
+    def __init__(self, console=None, disable=False):
+        self.console = console or Console()
+        self.disable = disable
+        self.progress = None
+        self.main_task = None
+        self.sub_task = None
+        self._started = False
+        self._old_handlers = []
+
+    def start(self, total_items, description="Processing"):
+        """Start the main progress bar."""
+        if self.disable:
+            return
+        self.progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            TextColumn("[dim]{task.fields[status]}"),
+            TimeRemainingColumn(),
+            console=self.console,
+            transient=False
+        )
+        self.progress.start()
+        self.main_task = self.progress.add_task(description, total=total_items, status="")
+        self._started = True
+
+        # Replace logging handlers with RichHandler that uses progress console
+        # This ensures logs appear above the progress bar
+        root_logger = logging.getLogger()
+        self._old_handlers = root_logger.handlers[:]
+        root_logger.handlers.clear()
+        rich_handler = RichHandler(
+            console=self.progress.console,
+            show_time=True,
+            show_path=False,
+            markup=True,
+            rich_tracebacks=True
+        )
+        rich_handler.setFormatter(logging.Formatter("%(message)s"))
+        root_logger.addHandler(rich_handler)
+
+    def update(self, advance=0, description=None, status=None):
+        """Update the main progress bar."""
+        if self.disable or not self._started or not self.progress:
+            return
+        update_kwargs = {}
+        if advance:
+            update_kwargs['advance'] = advance
+        if description is not None:
+            update_kwargs['description'] = description
+        if status is not None:
+            update_kwargs['status'] = status
+        if update_kwargs:
+            self.progress.update(self.main_task, **update_kwargs)
+
+    def set_status(self, status):
+        """Set the current operation status (shown in dim text)."""
+        if self.disable or not self._started or not self.progress:
+            return
+        self.progress.update(self.main_task, status=status)
+
+    def log(self, message):
+        """Print a message above the progress bar."""
+        if self.disable or not self._started or not self.progress:
+            return
+        self.progress.console.print(f"  [dim]{message}[/dim]")
+
+    def stop(self):
+        """Stop the progress bar."""
+        if self.disable or not self._started or not self.progress:
+            return
+        self.progress.stop()
+        self._started = False
+
+        # Restore original logging handlers
+        root_logger = logging.getLogger()
+        root_logger.handlers.clear()
+        for handler in self._old_handlers:
+            root_logger.addHandler(handler)
+        self._old_handlers = []

--- a/torcp/tmdbcache.py
+++ b/torcp/tmdbcache.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+"""
+TMDB query cache for torcp.
+Caches TMDB search results to avoid repeated API calls.
+"""
+
+import os
+import json
+import logging
+from datetime import datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+
+class TMDbCache:
+    """Cache for TMDB query results with TTL support."""
+
+    CACHE_DIR = "~/.torcp"
+    CACHE_FILE = "tmdb_cache.json"
+    TTL_DAYS = 30
+
+    def __init__(self, disabled=False):
+        self.disabled = disabled
+        self.cache = {}
+        self._dirty = False
+        if not disabled:
+            self._load()
+
+    def _get_cache_dir(self):
+        return os.path.expanduser(self.CACHE_DIR)
+
+    def _get_cache_path(self):
+        return os.path.join(self._get_cache_dir(), self.CACHE_FILE)
+
+    def _load(self):
+        """Load cache from disk."""
+        cache_path = self._get_cache_path()
+        if os.path.exists(cache_path):
+            try:
+                with open(cache_path, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                    self.cache = data.get('entries', {})
+                    logger.info(f"Loaded {len(self.cache)} entries from TMDB cache")
+            except (json.JSONDecodeError, IOError) as e:
+                logger.warning(f"Failed to load TMDB cache: {e}")
+                self.cache = {}
+
+    def _save(self):
+        """Save cache to disk."""
+        if self.disabled:
+            return
+
+        cache_dir = self._get_cache_dir()
+        if not os.path.exists(cache_dir):
+            os.makedirs(cache_dir)
+
+        cache_path = self._get_cache_path()
+        try:
+            data = {
+                'version': '1.0',
+                'updated': datetime.now().isoformat(),
+                'entries': self.cache
+            }
+            with open(cache_path, 'w', encoding='utf-8') as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+            logger.info(f"Saved {len(self.cache)} entries to TMDB cache")
+        except IOError as e:
+            logger.warning(f"Failed to save TMDB cache: {e}")
+
+    def _make_key(self, media_type, title, year):
+        """Create normalized cache key."""
+        normalized_title = title.lower().strip() if title else ''
+        year_str = str(year) if year else '0'
+        media_type_str = media_type.lower() if media_type else 'unknown'
+        return f"{media_type_str}|{normalized_title}|{year_str}"
+
+    def _is_expired(self, entry):
+        """Check if cache entry has expired."""
+        if 'timestamp' not in entry:
+            return True
+        try:
+            timestamp = datetime.fromisoformat(entry['timestamp'])
+            expiry = timestamp + timedelta(days=self.TTL_DAYS)
+            return datetime.now() > expiry
+        except (ValueError, TypeError):
+            return True
+
+    def get(self, key):
+        """Get cached result by key. Returns None if not found or expired."""
+        if self.disabled:
+            return None
+
+        if key not in self.cache:
+            return None
+
+        entry = self.cache[key]
+        if self._is_expired(entry):
+            logger.debug(f"Cache expired: {key}")
+            del self.cache[key]
+            self._dirty = True
+            return None
+
+        return entry
+
+    def get_by_search(self, media_type, title, year):
+        """Get cached result by search parameters."""
+        key = self._make_key(media_type, title, year)
+        return self.get(key)
+
+    def set(self, key, entry):
+        """Store result in cache."""
+        if self.disabled:
+            return
+
+        entry['timestamp'] = datetime.now().isoformat()
+        self.cache[key] = entry
+        self._dirty = True
+
+    def set_by_search(self, media_type, title, year, entry):
+        """Store result by search parameters."""
+        key = self._make_key(media_type, title, year)
+        self.set(key, entry)
+
+    def clear(self):
+        """Clear all cache entries."""
+        self.cache = {}
+        self._dirty = True
+        # Also delete the file
+        cache_path = self._get_cache_path()
+        if os.path.exists(cache_path):
+            try:
+                os.remove(cache_path)
+                logger.info("TMDB cache cleared")
+            except IOError as e:
+                logger.warning(f"Failed to delete cache file: {e}")
+
+    def close(self):
+        """Save cache to disk if modified."""
+        if self._dirty:
+            self._save()
+            self._dirty = False

--- a/torcp/tmdbparser.py
+++ b/torcp/tmdbparser.py
@@ -39,11 +39,14 @@ def transFromCCFCat(cat):
 
 
 def transToCCFCat(mediatype, originCat):
+    # If title parsing determined it's a movie category (Movie, MovieBDMV, MovieEncode, etc.),
+    # trust it over TMDB's tv result - TMDB multi-search may return wrong media type
+    if re.match(r'(movie)', originCat, re.I):
+        return originCat
     if mediatype == 'tv':
         return 'TV'
     elif mediatype == 'movie':
-        if not re.match(r'(movie)', originCat, re.I):
-            return 'Movie'
+        return 'Movie'
     return originCat
 
 

--- a/torcp/tmdbparser.py
+++ b/torcp/tmdbparser.py
@@ -107,18 +107,27 @@ class TMDbNameParser():
         return f"{media_type_str}|{normalized_title}|{year_str}"
 
     def _to_cache_entry(self):
-        """Convert current state to cache entry."""
-        return {
-            'tmdbid': self.tmdbid,
-            'title': self.title,
-            'year': self.year,
-            'tmdbcat': self.tmdbcat,
-            'original_language': self.original_language,
-            'popularity': self.popularity,
-            'genre_ids': self.genre_ids,
-            'poster_path': self.poster_path,
-            'release_air_date': self.release_air_date
-        }
+        """Convert current state to cache entry (JSON-serializable)."""
+        entry = {}
+        if self.tmdbid:
+            entry['tmdbid'] = int(self.tmdbid)
+        if self.title:
+            entry['title'] = str(self.title)
+        if self.year:
+            entry['year'] = int(self.year)
+        if self.tmdbcat:
+            entry['tmdbcat'] = str(self.tmdbcat)
+        if self.original_language:
+            entry['original_language'] = str(self.original_language)
+        if self.popularity:
+            entry['popularity'] = float(self.popularity)
+        if self.genre_ids:
+            entry['genre_ids'] = [int(g) if hasattr(g, '__int__') else g for g in self.genre_ids]
+        if self.poster_path:
+            entry['poster_path'] = str(self.poster_path)
+        if self.release_air_date:
+            entry['release_air_date'] = str(self.release_air_date)
+        return entry
 
     def _restore_from_cache(self, cached):
         """Restore state from cache entry."""

--- a/torcp/torcp.py
+++ b/torcp/torcp.py
@@ -814,7 +814,6 @@ class Torcp:
 
             if not self.isMediaFileType(file_ext):
                 logger.info('Skip : %s ' % movieItem)
-                self.record_skip(movieItem, "unsupported file type")
                 continue
 
             p = folderTmdbParser
@@ -952,6 +951,7 @@ class Torcp:
         # exportTargetDir = os.path.join(ARGS.hd_path, targetDir)
         exportTargetDir = targetDir
         logger.info('Target Dir: ' + exportTargetDir)
+        self.record_success()
         if self.EXPORT_OBJ:
             self.EXPORT_OBJ.onOneItemTorcped(exportTargetDir, self.CUR_MEDIA_NAME, tmdbidstr, tmdbcat, tmdbtitle, tmdbobj)
         if self.ARGS.after_copy_script:
@@ -1043,7 +1043,6 @@ class Torcp:
                     self.record_skip(itemName, "ISO file (use --full-bdmv)")
             else:
                 logger.info('Skip file:  %s ' % mediaSrc)
-                self.record_skip(itemName, "unsupported file type")
         else:
             if cat == self.CATNAME_TV:
                 self.copyTVFolderItems(mediaSrc, destFolderName, p.season, p.group,


### PR DESCRIPTION
 全部都是Claude vibe的，有啥问题我再改改
 
  1. 进度条显示 (--progress)

  使用 rich 库实现进度条功能，处理大量文件时可直观显示进度。

  torcp ... --progress

  2. TMDB 查询缓存

  自动缓存 TMDB 查询结果至 ~/.torcp/tmdb_cache.json，默认 30 天过期。重复运行时可大幅提升速度。

  - --no-tmdb-cache: 禁用缓存
  - --clear-tmdb-cache: 清除缓存

  3. 处理报告

  运行结束后显示处理统计摘要，包括成功/跳过/失败数量。

  - --save-skipped FILE: 保存跳过项目列表到文件
  - --save-failed FILE: 保存失败项目列表到文件

  4. 统一目录功能 (--unified-folders)

  将 BDMV/ISO 等格式按内容类型（电影/剧集）分类，而非按格式分类。启用后不再生成 BDMVISO、MovieM2TS 等单独目录。

  同时修复 HDTV 分类问题：HDTV 始终作为剧集处理。

  - --unified-folders: 启用统一目录模式
  - --tmdb-not-found-folder FOLDER: 自定义 TMDB 查询失败的目录名（默认：TMDbNotFound）